### PR TITLE
Connect to the BC6 decoding from Python

### DIFF
--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -101,6 +101,7 @@ DXGI_FORMAT_R8G8B8A8_UNORM_SRGB = 29
 DXGI_FORMAT_BC5_TYPELESS = 82
 DXGI_FORMAT_BC5_UNORM = 83
 DXGI_FORMAT_BC5_SNORM = 84
+DXGI_FORMAT_BC6H_UF16 = 95
 DXGI_FORMAT_BC7_TYPELESS = 97
 DXGI_FORMAT_BC7_UNORM = 98
 DXGI_FORMAT_BC7_UNORM_SRGB = 99
@@ -172,6 +173,10 @@ class DdsImageFile(ImageFile.ImageFile):
                 elif dxgi_format == DXGI_FORMAT_BC5_SNORM:
                     self.pixel_format = "BC5S"
                     n = 5
+                    self.mode = "RGB"
+                elif dxgi_format == DXGI_FORMAT_BC6H_UF16:
+                    self.pixel_format = "BC6"
+                    n = 6
                     self.mode = "RGB"
                 elif dxgi_format in (DXGI_FORMAT_BC7_TYPELESS, DXGI_FORMAT_BC7_UNORM):
                     self.pixel_format = "BC7"

--- a/src/decode.c
+++ b/src/decode.c
@@ -376,11 +376,8 @@ PyImaging_BcnDecoderNew(PyObject *self, PyObject *args) {
             actual = "L";
             break;
         case 5: /* BC5: 2-channel 8-bit via 2 BC3 alpha blocks */
-            actual = "RGB";
-            break;
         case 6: /* BC6: 3-channel 16-bit float */
-            /* TODO: support 4-channel floating point images */
-            actual = "RGBAF";
+            actual = "RGB";
             break;
         default:
             PyErr_SetString(PyExc_ValueError, "block compression type unknown");

--- a/src/libImaging/BcnDecode.c
+++ b/src/libImaging/BcnDecode.c
@@ -673,7 +673,7 @@ bc6_finalize(int v, int sign) {
             return (UINT8)half_to_float((UINT16)((v * 31) / 32));
         }
     } else {
-        return (UINT8)half_to_float((UINT16)((v * 31) / 64));
+        return v >> 8;
     }
 }
 


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/6449

Two changes here.
1. Connect to the BC6 decoding from Python

After this PR, with your code as well,
```python
from PIL import Image
im = Image.open("source.dds")
im.save("out.png")
```
gives

<img src="https://user-images.githubusercontent.com/3112309/179489553-650ff55a-c90f-424e-ab8d-da14dc62fefd.png" width="300" />

3. Change `bc6_finalize` for unsigned data.

As per the comment in the code, the `half_to_float` function is taken from https://gist.github.com/rygorous/2144712. It is `half_to_float_fast5`. Except, that code is for converting FP16 into FP32. FP16 has [1 sign bit, 5 exponent bits and then 10 bits for the fraction](https://en.wikipedia.org/wiki/Half-precision_floating-point_format#Half_precision_examples). Unsigned BC6H has [5 exponent bits and then 11 bits for the fraction](https://docs.microsoft.com/en-us/windows/win32/direct3d11/bc6h-format#sign-extension-for-endpoint-values). So instead of scaling it down from 65535 to 31743, I'm just scaling it down to 255.