### PR TITLE
Rename format to BC6H and BC6HS

### DIFF
--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -14,8 +14,8 @@ TEST_FILE_DX10_BC5_TYPELESS = "Tests/images/bc5_typeless.dds"
 TEST_FILE_DX10_BC5_UNORM = "Tests/images/bc5_unorm.dds"
 TEST_FILE_DX10_BC5_SNORM = "Tests/images/bc5_snorm.dds"
 TEST_FILE_BC5S = "Tests/images/bc5s.dds"
-TEST_FILE_BC6 = "Tests/images/bc6h.dds"
-TEST_FILE_BC6S = "Tests/images/bc6h_sf.dds"
+TEST_FILE_BC6H = "Tests/images/bc6h.dds"
+TEST_FILE_BC6HS = "Tests/images/bc6h_sf.dds"
 TEST_FILE_DX10_BC7 = "Tests/images/bc7-argb-8bpp_MipMaps-1.dds"
 TEST_FILE_DX10_BC7_UNORM_SRGB = "Tests/images/DXGI_FORMAT_BC7_UNORM_SRGB.dds"
 TEST_FILE_DX10_R8G8B8A8 = "Tests/images/argb-32bpp_MipMaps-1.dds"
@@ -91,12 +91,12 @@ def test_dx10_bc5(image_path, expected_path):
 @pytest.mark.parametrize(
     ("image_path", "expected_path"),
     (
-        (TEST_FILE_BC6, TEST_FILE_BC6),
-        (TEST_FILE_BC6S, TEST_FILE_BC6S),
+        (TEST_FILE_BC6H, TEST_FILE_BC6H),
+        (TEST_FILE_BC6HS, TEST_FILE_BC6HS),
     ),
 )
-def test_dx10_bc6(image_path, expected_path):
-    """Check DX10 BC6/BC6S images can be opened"""
+def test_dx10_bc6h(image_path, expected_path):
+    """Check DX10 BC6H/BC6HS images can be opened"""
 
     with Image.open(image_path) as im:
         im.load()

--- a/Tests/test_file_dds.py
+++ b/Tests/test_file_dds.py
@@ -88,14 +88,8 @@ def test_dx10_bc5(image_path, expected_path):
         assert_image_equal_tofile(im, expected_path.replace(".dds", ".png"))
 
 
-@pytest.mark.parametrize(
-    ("image_path", "expected_path"),
-    (
-        (TEST_FILE_BC6H, TEST_FILE_BC6H),
-        (TEST_FILE_BC6HS, TEST_FILE_BC6HS),
-    ),
-)
-def test_dx10_bc6h(image_path, expected_path):
+@pytest.mark.parametrize("image_path", (TEST_FILE_BC6H, TEST_FILE_BC6HS))
+def test_dx10_bc6h(image_path):
     """Check DX10 BC6H/BC6HS images can be opened"""
 
     with Image.open(image_path) as im:
@@ -105,7 +99,7 @@ def test_dx10_bc6h(image_path, expected_path):
         assert im.mode == "RGB"
         assert im.size == (256, 256)
 
-        assert_image_equal_tofile(im, expected_path.replace(".dds", ".png"))
+        assert_image_equal_tofile(im, image_path.replace(".dds", ".png"))
 
 
 def test_dx10_bc7():

--- a/src/PIL/DdsImagePlugin.py
+++ b/src/PIL/DdsImagePlugin.py
@@ -176,11 +176,11 @@ class DdsImageFile(ImageFile.ImageFile):
                     n = 5
                     self.mode = "RGB"
                 elif dxgi_format == DXGI_FORMAT_BC6H_UF16:
-                    self.pixel_format = "BC6"
+                    self.pixel_format = "BC6H"
                     n = 6
                     self.mode = "RGB"
                 elif dxgi_format == DXGI_FORMAT_BC6H_SF16:
-                    self.pixel_format = "BC6S"
+                    self.pixel_format = "BC6HS"
                     n = 6
                     self.mode = "RGB"
                 elif dxgi_format in (DXGI_FORMAT_BC7_TYPELESS, DXGI_FORMAT_BC7_UNORM):


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6449

Match the name "BC6H", as seen at https://docs.microsoft.com/en-us/windows/win32/direct3d11/texture-block-compression-in-direct3d-11#bc6h-format